### PR TITLE
relaxing constraint for extension name validation

### DIFF
--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -224,7 +224,7 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
     }
 
     /**
-     * Validates the extension name as defined in  CloudEvents spec.
+     * Validates the extension name as defined in CloudEvents spec.
      *
      * @param name the extension name
      * @return true if extension name is valid, false otherwise
@@ -240,7 +240,7 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
     }
 
     private static boolean isValidChar(char c) {
-        return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+        return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_';
     }
 
     protected void requireValidAttributeWrite(String name) {

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                    <configuration>
+                        <excludes>
+                            <exclude>**/*TestMicroprofile.java</exclude>
+                        </excludes>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Maven plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Maven plugins -->


### PR DESCRIPTION
Relaxing contraint for validating extension names allowing names with `_` also