### PR TITLE
Cloudevents patch

### DIFF
--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -240,7 +240,7 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
     }
 
     private static boolean isValidChar(char c) {
-        return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_';
+        return ((c >= 'a' || c >= 'A') && (c <= 'z' || c <= 'Z')) || (c >= '0' && c <= '9') || c == '_';
     }
 
     protected void requireValidAttributeWrite(String name) {

--- a/core/src/test/java/io/cloudevents/core/impl/BaseCloudEventBuilderTest.java
+++ b/core/src/test/java/io/cloudevents/core/impl/BaseCloudEventBuilderTest.java
@@ -67,7 +67,7 @@ public class BaseCloudEventBuilderTest {
         });
     }
 
-    @Test
+    /*@Test
     public void testInvalidExtensionName() {
         Exception exception = assertThrows(RuntimeException.class, () -> {
             CloudEvent cloudEvent = CloudEventBuilder.v1(Data.V1_WITH_JSON_DATA_WITH_EXT)
@@ -78,7 +78,7 @@ public class BaseCloudEventBuilderTest {
         String actualMessage = exception.getMessage();
 
         assertTrue(actualMessage.contains(expectedMessage));
-    }
+    }*/
 
     @Test
     public void testBinaryExtension() {

--- a/core/src/test/java/io/cloudevents/core/impl/BaseCloudEventBuilderTest.java
+++ b/core/src/test/java/io/cloudevents/core/impl/BaseCloudEventBuilderTest.java
@@ -67,7 +67,7 @@ public class BaseCloudEventBuilderTest {
         });
     }
 
-    @Test
+   /* @Test
     public void testInvalidExtensionName() {
         Exception exception = assertThrows(RuntimeException.class, () -> {
             CloudEvent cloudEvent = CloudEventBuilder.v1(Data.V1_WITH_JSON_DATA_WITH_EXT)
@@ -78,7 +78,7 @@ public class BaseCloudEventBuilderTest {
         String actualMessage = exception.getMessage();
 
         assertTrue(actualMessage.contains(expectedMessage));
-    }
+    }*/
 
     @Test
     public void testBinaryExtension() {

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,11 @@
                         </excludes>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.7</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
Relaxing constraint for invalid extension name (containing upper case letters). This will be used in `eventsingress` to let payloads with such extensions to come in so that we can catch and notify us to the publishers migrate to new extension format